### PR TITLE
Fix Github Actions Workflow (missing next-env.d.ts)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - feat/testing
+      - main
 
 jobs:
   changed_files:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - feat/testing
 
 jobs:
   changed_files:
@@ -31,12 +31,20 @@ jobs:
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
+        if: steps.changed-files.outputs.all_changed_files != ''
+        working-directory: ./frontend
         with:
-          node-version: '20' # Atau versi Node.js yang Anda gunakan
+          node-version: "20" # Atau versi Node.js yang Anda gunakan
 
       - name: Install dependencies
+        if: steps.changed-files.outputs.all_changed_files != ''
         working-directory: ./frontend
         run: npm install
+
+      - name: Build next.js
+        if: steps.changed-files.outputs.all_changed_files != ''
+        working-directory: ./frontend
+        run: npm run build
 
       - name: Run tests
         if: steps.changed-files.outputs.all_changed_files != ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         if: steps.changed-files.outputs.all_changed_files != ''
-        working-directory: ./frontend
         with:
           node-version: "20" # Atau versi Node.js yang Anda gunakan
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,6 @@ jobs:
         working-directory: ./frontend
         run: npm install
 
-      - name: Build next.js
-        if: steps.changed-files.outputs.all_changed_files != ''
-        working-directory: ./frontend
-        run: npm run build
-
       - name: Run tests
         if: steps.changed-files.outputs.all_changed_files != ''
         working-directory: ./frontend

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,4 +34,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -33,5 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
The missing next-env.d.ts is necessary to let tsc know how to handle module.css imports, which is what caused the errors in the previous verification phase.